### PR TITLE
add: reward normalization

### DIFF
--- a/08_1_pg_cartpole.py
+++ b/08_1_pg_cartpole.py
@@ -99,6 +99,8 @@ for step in range(max_num_episodes):
         if done:
             # Determine standardized rewards
             discounted_rewards = discount_rewards(rewards)
+            # Normalization
+            discounted_rewards = (discounted_rewards - discounted_rewards.mean())/(discounted_rewards.std() + 1e-7)
             l, _ = sess.run([loss, train],
                             feed_dict={X: xs, Y: ys, advantages: discounted_rewards})
 

--- a/08_2_softmax_pg_cartpole.py
+++ b/08_2_softmax_pg_cartpole.py
@@ -95,6 +95,8 @@ for i in range(num_episodes):
         if done:
             # Determine standardized rewards
             discounted_rewards = discount_rewards(rewards, gamma)
+            # Normalization
+            discounted_rewards = (discounted_rewards - discounted_rewards.mean())/(discounted_rewards.std() + 1e-7)
             ll, la, l, _ = sess.run([log_lik, log_lik_adv, loss, train], feed_dict={X: xs,
                                                                                     Y: ys,
                                                                                     advantages: discounted_rewards})


### PR DESCRIPTION
Summary
------
1. [Add (back)] the reward mean normalization
   - Why? The normalization reduces the variance of the gradient estimator, and it's not shifting the expected value. Normalization actually works as the baseline as shown in (2).
![gradient_estimator](https://cloud.githubusercontent.com/assets/2981167/24579999/7dd301e4-16b5-11e7-819a-9610a53d45b1.png)
   
    - In fact, I underestimated the effects of adding the baseline.. It helps to reduce the variance significantly.
