### PR TITLE
fix: DQN

### DIFF
--- a/07_2_dqn_2013_cartpole.py
+++ b/07_2_dqn_2013_cartpole.py
@@ -1,9 +1,9 @@
-'''
+"""
 This code is based on:
 https://github.com/hunkim/DeepRL-Agents
 
 CF https://github.com/golbin/TensorFlow-Tutorials
-'''
+"""
 import numpy as np
 import tensorflow as tf
 import random
@@ -12,19 +12,40 @@ from collections import deque
 
 import gym
 env = gym.make('CartPole-v0')
-
+env = gym.wrappers.Monitor(env, 'gym-results/', force=True)
 # Constants defining our neural network
-input_size = env.observation_space.shape[0]
-output_size = env.action_space.n
+INPUT_SIZE = env.observation_space.shape[0]
+OUTPUT_SIZE = env.action_space.n
 
-dis = 0.9
+# Q(s, a) = r + discount_rate * max Q(s_next, a)
+DISCOUNT_RATE = 0.99
 REPLAY_MEMORY = 50000
+MAX_EPISODE = 5000
+BATCH_SIZE = 32
+
+# minimum epsilon for epsilon greedy
+MIN_E = 0.01
+# if epsilon decaying_episode = 100
+# epsilon lineary decreases to MIN_E over 100 episodes
+EPSILON_DECAYING_EPISODE = MAX_EPISODE * 0.1
 
 
 def bot_play(mainDQN):
-    # See our trained network in action
+    """ Run a single episode with the DQN agent
+
+    Parameters
+    ----------
+    mainDQN : DQN agent
+
+    Returns
+    ----------
+    reward : float
+        Episode reward is returned
+    """
+
     state = env.reset()
     reward_sum = 0
+
     while True:
         env.render()
         action = np.argmax(mainDQN.predict(state))
@@ -36,55 +57,145 @@ def bot_play(mainDQN):
 
 
 def simple_replay_train(DQN, train_batch):
-    x_stack = np.empty(0).reshape(0, DQN.input_size)
-    y_stack = np.empty(0).reshape(0, DQN.output_size)
+    """ Prepare X_batch, y_batch and train them
 
-    # Get stored information from the buffer
-    for state, action, reward, next_state, done in train_batch:
-        Q = DQN.predict(state)
+    Recall our loss function is
+        target = reward + discount * max Q(s',a)
+                 or reward if done early
 
-        # terminal?
-        if done:
-            Q[0, action] = reward
-        else:
-            # Obtain the Q' values by feeding the new state through our network
-            Q[0, action] = reward + dis * np.max(DQN.predict(next_state))
+        Loss function: [target - Q(s, a)]^2
 
-        y_stack = np.vstack([y_stack, Q])
-        x_stack = np.vstack([x_stack, state])
+    Hence,
+
+        X_batch is a state list
+        y_batch is reward + discount * max Q
+                   or reward if terminated early
+
+    Parameters
+    ----------
+    DQN : DQN Agent
+
+    train_batch : list, [item_1, item_2, ..., item_batchsize]
+        where item_i is also a list
+        item_i = [state, action, reward, next_state, done]
+
+    """
+    # We use numpy to vectorize operations
+    tmp = np.asarray(train_batch)
+
+    # state_array.shape = (batch_size, 4)
+    state_array = np.vstack(tmp[:, 0])
+
+    # action_array.shape = (batch_size, )
+    action_array = tmp[:, 1].astype(np.int32)
+
+    # reward_array.shape = (batch_size, )
+    reward_array = tmp[:, 2]
+
+    # next_state_array.shape = (batch_size, 4)
+    next_state_array = np.vstack(tmp[:, 3])
+
+    # done_array.shape = (batch_size, )
+    done_array = tmp[:, 4].astype(np.int32)
+
+    X_batch = state_array
+    y_batch = DQN.predict(state_array)
+
+    # We use a vectorized operation
+    target = reward_array + DISCOUNT_RATE * np.max(DQN.predict(next_state_array), 1) * (1 - done_array)
+    y_batch[np.arange(len(X_batch)), action_array] = target
 
     # Train our network using target and predicted Q values on each episode
-    return DQN.update(x_stack, y_stack)
+    return DQN.update(X_batch, y_batch)
+
+
+def annealing_epsilon(episode, min_e, max_e, target_episode):
+    """Return an linearly annealed epsilon
+
+    Parameters
+    ----------
+
+        (epsilon)
+            |
+   max_e ---|\
+            | \
+            |  \
+            |   \
+   min_e ---|____\_______________(episode)
+                 |
+                target_episode
+
+    slope = (min_e - max_e) / (target_episode)
+    intercept = max_e
+
+    e = slope * episode + intercept
+    """
+
+    slope = (min_e - max_e) / (target_episode)
+    intercept = max_e
+
+    return max(min_e, slope * episode + intercept)
 
 
 def main():
-    max_episodes = 5000
+    """
+    pseudocode
+
+    For episode = 1, ..., M
+
+        s = initital state
+
+        For t = 1, ..., T
+
+            action = argmax Q(s, a)
+
+            Get s2, r, d by playing the action
+
+            save [s,a,r,s2,d] to memory
+
+            take a minibatch from memory
+
+            y = r
+                or r + d * max Q(s2, ...)
+
+            Perform train step on (y - Q(s, a))^2
+
+    """
 
     # store the previous observations in replay memory
     replay_buffer = deque()
 
+    # Check whether we clear the game
+    # CartPole Clear Condition
+    # Avg Reward >= 195 over 100 games
+    # We will choose more strict condition by setting 199
+    last_100_game_reward = deque()
+
     with tf.Session() as sess:
-        mainDQN = dqn.DQN(sess, input_size, output_size)
-        tf.global_variables_initializer().run()
+        mainDQN = dqn.DQN(sess, INPUT_SIZE, OUTPUT_SIZE)
+        init = tf.global_variables_initializer()
+        sess.run(init)
 
-        for episode in range(max_episodes):
-            e = 1. / ((episode / 10) + 1)
+        for episode in range(MAX_EPISODE):
+            e = annealing_epsilon(episode, MIN_E, 1.0, EPSILON_DECAYING_EPISODE)
             done = False
-            step_count = 0
-
             state = env.reset()
 
+            step_count = 0
             while not done:
-                if np.random.rand(1) < e:
+
+                if np.random.rand() < e:
                     action = env.action_space.sample()
+
                 else:
                     # Choose an action by greedily from the Q-network
                     action = np.argmax(mainDQN.predict(state))
 
                 # Get new state and reward from environment
                 next_state, reward, done, _ = env.step(action)
-                if done:  # big penalty
-                    reward = -100
+
+                if done:
+                    reward = -1
 
                 # Save the experience to our buffer
                 replay_buffer.append((state, action, reward, next_state, done))
@@ -93,23 +204,29 @@ def main():
 
                 state = next_state
                 step_count += 1
-                if step_count > 10000:  # Good enough
+
+                if step_count % 4 == 0 and len(replay_buffer) > BATCH_SIZE:
+                    # Minibatch works better
+                    minibatch = random.sample(replay_buffer, BATCH_SIZE)
+                    simple_replay_train(mainDQN, minibatch)
+
+            print("[Episode {:>5}]  steps: {:>5} e: {:>5.2f}".format(episode, step_count, e))
+
+            last_100_game_reward.append(step_count)
+
+            if len(last_100_game_reward) > 100:
+
+                last_100_game_reward.popleft()
+
+                avg_reward = np.mean(last_100_game_reward)
+                if avg_reward > 199.0:
+                    print("Game Cleared within {} episodes with avg reward {}".format(episode, avg_reward))
                     break
 
-            print("Episode: {}  steps: {}".format(episode, step_count))
-            if step_count > 10000:
-                pass
-                # break
+        # Test run 5 times
+        for _ in range(5):
+            bot_play(mainDQN)
 
-            if episode % 10 == 1:  # train every 10 episodes
-                # Get a random batch of experiences.
-                for _ in range(50):
-                    # Minibatch works better
-                    minibatch = random.sample(replay_buffer, 10)
-                    loss, _ = simple_replay_train(mainDQN, minibatch)
-                print("Loss: ", loss)
-
-        bot_play(mainDQN)
 
 if __name__ == "__main__":
     main()

--- a/07_3_dqn_2015_cartpole.py
+++ b/07_3_dqn_2015_cartpole.py
@@ -113,6 +113,8 @@ def main():
     # store the previous observations in replay memory
     replay_buffer = deque()
 
+    last_100_game_reward = deque()
+
     with tf.Session() as sess:
         mainDQN = dqn.DQN(sess, input_size, output_size, name="main")
         targetDQN = dqn.DQN(sess, input_size, output_size, name="target")
@@ -148,13 +150,8 @@ def main():
 
                 state = next_state
                 step_count += 1
-                if step_count > 10000:  # Good enough. Let's move on
-                    break
 
             print("Episode: {}  steps: {}".format(episode, step_count))
-            if step_count > 10000:
-                pass
-              #  break
 
             if episode % 10 == 1:  # train every 10 episode
                 # Get a random batch of experiences.
@@ -165,6 +162,17 @@ def main():
                 print("Loss: ", loss)
                 # copy q_net -> target_net
                 sess.run(copy_ops)
+
+            last_100_game_reward.append(step_count)
+
+            if len(last_100_game_reward) > 100:
+                last_100_game_reward.popleft()
+
+                avg_reward = np.mean(last_100_game_reward)
+
+                if avg_reward > 199:
+                    print(f"Game Cleared in {episode} episodes with avg reward {avg_reward}")
+                    break
 
         # See our trained bot in action
         env2 = wrappers.Monitor(env, 'gym-results', force=True)

--- a/dqn.py
+++ b/dqn.py
@@ -28,22 +28,14 @@ class DQN:
 
         self._build_network()
 
-    def _build_network(self, h_size=10, l_rate=1e-1):
+    def _build_network(self, h_size=16, l_rate=0.01):
         with tf.variable_scope(self.net_name):
-            self._X = tf.placeholder(
-                tf.float32, [None, self.input_size], name="input_x")
+            self._X = tf.placeholder(tf.float32, [None, self.input_size], name="input_x")
+            net = self._X
 
-            # First layer of weights
-            W1 = tf.get_variable("W1", shape=[self.input_size, h_size],
-                                 initializer=tf.contrib.layers.xavier_initializer())
-            layer1 = tf.nn.tanh(tf.matmul(self._X, W1))
-
-            # Second layer of weights
-            W2 = tf.get_variable("W2", shape=[h_size, self.output_size],
-                                 initializer=tf.contrib.layers.xavier_initializer())
-
-            # Q prediction
-            self._Qpred = tf.matmul(layer1, W2)
+            net = tf.layers.dense(net, h_size, activation=tf.nn.relu)
+            net = tf.layers.dense(net, self.output_size)
+            self._Qpred = net
 
         # We need to define the parts of the network needed for learning a
         # policy


### PR DESCRIPTION
## summary
- related issue: #6 
- modify the dqn (ver 2013) and dqn.py 
## change
1. lots of modifications in [07_2_dqn_2013_cartpole.py](https://github.com/hunkim/ReinforcementZeroToAll/compare/master...kkweon:fix/dqn?diff=unified&expand=1&name=fix%2Fdqn#diff-9a1790cffcff88085783e6c12574fc13)
- add the monitor: a running example of this file is [here](https://gym.openai.com/evaluations/eval_NaANns6OTCG78eyJ5J2zJg)
- I tried to keep the code as same as in the paper
    * discount rate = 0.99
    * batch size = 32
    * online learning (DQN is an online algorithm but originally in the code, it was sort of offline learning)
    * reward range (-1, 1)
    * vectorized operation instead of looping over
    * epsilon is annealed linearly as in the paper
- usually clear in 500 episodes

2. In [07_3_dqn_2015_cartpole.py](https://github.com/hunkim/ReinforcementZeroToAll/compare/master...kkweon:fix/dqn?diff=unified&expand=1&name=fix%2Fdqn#diff-cc8812afff06da199aa02eae50961551), however, I only added the CartPole clear condition
- it will also clear the game but slower than the above file
    - usually clear in 1,200 episodes
    - note that hyper parameters are also different
- I kept the core untouched for further research


3. In [dqn.py](https://github.com/hunkim/ReinforcementZeroToAll/compare/master...kkweon:fix/dqn?diff=unified&expand=1&name=fix%2Fdqn#diff-c0fcf8b540e0f7cd69c9ad758c0c0893)
- relu instead of tanh (as in the original paper)
- high level api instead of low level so that it's easier to modify the network architecture